### PR TITLE
fix-okta-source-rate-limit-backoff

### DIFF
--- a/airbyte-integrations/connectors/source-okta/source_okta/manifest.yaml
+++ b/airbyte-integrations/connectors/source-okta/source_okta/manifest.yaml
@@ -46,13 +46,15 @@ definitions:
         headers.link.next.url == headers.link.self.url) }}
 
   error_handler:
-    type: CompositeErrorHandler
-    error_handlers:
-      - type: DefaultErrorHandler
-        backoff_strategies:
-          - type: WaitUntilTimeFromHeader
-            header: X-Rate-Limit-Reset
-            min_wait: "60"
+    type: DefaultErrorHandler
+    backoff_strategies:
+      - type: WaitTimeFromHeader
+        header: Retry-After
+      - type: WaitUntilTimeFromHeader
+        header: X-Rate-Limit-Reset
+        min_wait: "60"
+      - type: ConstantBackoffStrategy
+        backoff_time_in_seconds: 60
 
   groups_stream:
     $parameters:
@@ -1039,20 +1041,22 @@ streams:
         authenticator:
           $ref: "#/definitions/selective_authenticator"
         error_handler:
-          type: CompositeErrorHandler
-          error_handlers:
-            - type: DefaultErrorHandler
-              backoff_strategies:
-                - type: WaitUntilTimeFromHeader
-                  header: X-Rate-Limit-Reset
-                  min_wait: "60"
-              response_filters:
-                - type: HttpResponseFilter
-                  action: IGNORE
-                  predicate: "{{ response.errorCode == 'E0000001' }}"
-                  http_codes:
-                    - 400
-                  error_message: "{{ response.errorSummary }}"
+          type: DefaultErrorHandler
+          backoff_strategies:
+            - type: WaitTimeFromHeader
+              header: Retry-After
+            - type: WaitUntilTimeFromHeader
+              header: X-Rate-Limit-Reset
+              min_wait: "60"
+            - type: ConstantBackoffStrategy
+              backoff_time_in_seconds: 60
+          response_filters:
+            - type: HttpResponseFilter
+              action: IGNORE
+              predicate: "{{ response.errorCode == 'E0000001' }}"
+              http_codes:
+                - 400
+              error_message: "{{ response.errorSummary }}"
         request_body_json: {}
       record_selector:
         type: RecordSelector


### PR DESCRIPTION
## Change
- Chain HTTP backoff for `source-okta`: `Retry-After` → `X-Rate-Limit-Reset` (with existing `min_wait`) → constant 60s.
- Replace `CompositeErrorHandler` wrapper with a single `DefaultErrorHandler` for the shared definition and align the `logs` stream handler (keep the `E0000001` IGNORE on 400).

## Why
Okta syncs could log `UserDefinedBackoffException: Too many requests` with `Backing off ... for 0.0s`, effectively immediate retries and extra 429 pressure. The added strategies ensure a non-zero wait when headers do not yield one.

Upstream contribution: https://github.com/airbytehq/airbyte/pull/76029

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches HTTP error/backoff behavior for all Okta streams, which can change retry timing and sync throughput; low code complexity but impacts runtime behavior under rate limiting.
> 
> **Overview**
> Improves `source-okta` rate-limit handling by replacing the prior `CompositeErrorHandler` wrapper with a single `DefaultErrorHandler` and chaining multiple backoff strategies.
> 
> Backoff now prefers `Retry-After`, falls back to `X-Rate-Limit-Reset` (with the existing `min_wait`), and finally uses a constant 60s delay to avoid zero-wait retries; the `logs` stream is aligned to this behavior while preserving the existing 400 `E0000001` *IGNORE* filter.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14ac9010a00fb7188814ac0b876435d363c4c7f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->